### PR TITLE
Initial build-tools improvements

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: Google
+IndentWidth: 4
+ColumnLimit: 100

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,32 @@
+name: Google C++ Lint
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+
+jobs:
+  cpplint:
+    name: cpplint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Install lint dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install cpplint
+
+      - name: Run cpplint (Google C++ style)
+        run: make lint

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,1 @@
+set noparent

--- a/Firmware/old/CPPLINT.cfg
+++ b/Firmware/old/CPPLINT.cfg
@@ -1,0 +1,2 @@
+set noparent
+exclude_files=.*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,119 @@
+# Make help the default output so users discover the available tooling targets.
+.DEFAULT_GOAL := help
+
+# ------------------------------------------------------------------------------
+# Tooling configuration
+# ------------------------------------------------------------------------------
+CXX       ?= g++
+CXXFLAGS  ?= -std=c++17 -Wall -Wextra
+SRC_DIR   := Firmware/motherBoard/src
+TEST_DIR  := tests
+BUILD_DIR := build
+HOST_DEFINES := -DINCUNEST_HOST_BUILD
+INCLUDES  := -I./$(SRC_DIR) -I./Firmware/motherBoard/include -I./Firmware/motherBoard/include/host_stubs
+
+LINT_TOOL   ?= cpplint
+FORMAT_TOOL ?= clang-format
+LDLIBS      ?= -lgtest -lgtest_main -pthread
+
+# ------------------------------------------------------------------------------
+# Source discovery
+# ------------------------------------------------------------------------------
+SRCS        := $(wildcard $(SRC_DIR)/*.cpp)
+HDRS        := $(wildcard $(SRC_DIR)/*.h)
+OBJS        := $(patsubst $(SRC_DIR)/%.cpp,$(BUILD_DIR)/%.o,$(SRCS))
+
+# Split out main.cpp so test builds can reuse the rest of the sources
+NON_MAIN_SRCS := $(filter-out $(SRC_DIR)/main.cpp,$(SRCS))
+TEST_SRCS     := $(wildcard $(TEST_DIR)/test_*.cpp)
+
+# ------------------------------------------------------------------------------
+# Default target – host build to catch compile issues early
+# ------------------------------------------------------------------------------
+all: firmware.out
+
+firmware.out: $(OBJS)
+	$(CXX) $(CXXFLAGS) $(HOST_DEFINES) $(INCLUDES) $^ -o $@
+
+$(BUILD_DIR)/%.o: $(SRC_DIR)/%.cpp | $(BUILD_DIR)
+	$(CXX) $(CXXFLAGS) $(HOST_DEFINES) $(INCLUDES) -c $< -o $@
+
+$(BUILD_DIR):
+	@mkdir -p $@
+
+# ------------------------------------------------------------------------------
+# Lint – Google C++ style via cpplint
+# ------------------------------------------------------------------------------
+lint:
+	$(LINT_TOOL) $(SRCS) $(HDRS)
+
+# ------------------------------------------------------------------------------
+# Format – enforce Google style via clang-format
+# ------------------------------------------------------------------------------
+format:
+	$(FORMAT_TOOL) -style=google -i $(SRCS) $(HDRS)
+
+# ------------------------------------------------------------------------------
+# Tests – build everything except main.cpp + link GoogleTest suites
+# ------------------------------------------------------------------------------
+ifeq ($(strip $(TEST_SRCS)),)
+test:
+	@echo "No tests found in $(TEST_DIR); nothing to run."
+else
+test: run_tests
+	./run_tests
+
+run_tests: $(NON_MAIN_SRCS) $(TEST_SRCS)
+	$(CXX) $(CXXFLAGS) $(HOST_DEFINES) $(INCLUDES) $^ -o $@ $(LDLIBS)
+endif
+
+# ------------------------------------------------------------------------------
+# Clean – remove build artifacts
+# ------------------------------------------------------------------------------
+clean:
+	rm -rf $(BUILD_DIR) firmware.out run_tests
+
+
+# ------------------------------------------------------------------------------
+# Deps – install cpplint, clang-format, and gtest toolchain prerequisites
+# ------------------------------------------------------------------------------
+deps:
+	@set -e; \
+	OS=$$(uname -s); \
+	if [ "$$OS" = "Darwin" ]; then \
+		if command -v brew >/dev/null 2>&1; then \
+			brew update; \
+			brew install cpplint clang-format googletest || true; \
+		else \
+			echo "Homebrew not found. Install it from https://brew.sh to continue." >&2; \
+			exit 1; \
+		fi; \
+	elif [ "$$OS" = "Linux" ]; then \
+		if command -v apt-get >/dev/null 2>&1; then \
+			sudo apt-get update; \
+			sudo apt-get install -y cpplint clang-format build-essential cmake libgtest-dev || exit 1; \
+			if [ -d /usr/src/googletest ]; then \
+				cd /usr/src/googletest && sudo cmake . && sudo cmake --build . --target install; \
+			fi; \
+		else \
+			echo "Unsupported Linux package manager. Install clang-format, googletest, and pip manually." >&2; \
+			exit 1; \
+		fi; \
+	else \
+		echo "Unsupported OS: $$OS. Install clang-format, googletest, and cpplint manually." >&2; \
+		exit 1; \
+	fi; \
+
+# ------------------------------------------------------------------------------
+# Help – list the most useful targets
+# ------------------------------------------------------------------------------
+help:
+	@echo "Available targets:"
+	@echo "  make all      - Build firmware.out from all sources for host testing"
+	@echo "  make lint     - Run cpplint (Google C++ style) on active firmware sources"
+	@echo "  make format   - Apply clang-format -style=google to active firmware sources"
+	@echo "  make test     - Build & execute GoogleTest suites in ./tests"
+	@echo "  make clean    - Remove build artifacts (build/, firmware.out, run_tests)"
+	@echo "  make deps     - Install cpplint, clang-format, and gtest toolchain prerequisites"
+
+.PHONY: help all lint format test clean deps


### PR DESCRIPTION
This pull request introduces a consistent C++ tooling setup for the project, focusing on enforcing Google C++ style guidelines and streamlining developer workflows. The changes add configuration files for formatting and linting, a GitHub Actions workflow for automated lint checks, and a comprehensive `Makefile` with targets for building, linting, formatting, testing, and dependency management.

**Tooling and Workflow Enhancements:**

* Added a `Makefile` that defines targets for building the firmware, running Google C++ style linting (`cpplint`), formatting code (`clang-format`), running GoogleTest-based tests, cleaning build artifacts, and installing dependencies. This makes common development tasks easy and consistent.
* Introduced a GitHub Actions workflow (`.github/workflows/lint.yml`) to automatically run `cpplint` on pull requests and pushes to main/master, ensuring code style compliance in CI.

**Style and Lint Configuration:**

* Added a `.clang-format` file to enforce Google C++ style with specific indentation and column limit settings.
* Added `CPPLINT.cfg` files at the root and in `Firmware/old/` to control `cpplint` behavior, with the latter excluding all files in its directory from linting. 