### PR TITLE
docs(alarms): expandir el bloque B de verificacion en banco

### DIFF
--- a/Firmware/docs/alarms_bench_verification.md
+++ b/Firmware/docs/alarms_bench_verification.md
@@ -172,114 +172,272 @@ de ThingsBoard que la usen hay que migrarlos.
 
 ## Bloque B — todo lo acumulado sin verificar
 
-Nada de lo que sigue se ha visto funcionar en hardware. Son ~70 commits de
-trabajo con cobertura nativa donde la había y **cero ejecución real**.
+Nada de lo que sigue se ha visto funcionar en hardware. Son ~80 commits con
+cobertura nativa donde la había y **cero ejecución real**.
 
-**Antes de empezar: flashear LAS DOS placas.** En esta tanda cambiaron el enum
-de alarmas (17 condiciones), `CTRL,STATE` (dos campos nuevos), `CTRL,ALM`
-(prioridad) y `CTRL,ALM_HISTORY` (campo `resolved`). Una placa vieja contra un
-display nuevo descarta líneas enteras.
+Cada punto lleva **Preparación / Pasos / Debe ocurrir / Si falla**. El apartado
+"si falla" no es relleno: dice dónde mirar, y está para que un fallo no se
+convierta en una sesión de depuración a ciegas como la del indicador de AUDIO
+PAUSED (`known_issues.md` #6).
 
-**Atajo:** el punto 11 (prueba de función de alarma) ejercita de una vez el
-zumbador, el banner, los tres patrones de prioridad y los tres colores. Hazlo
-el primero: si falla, casi todo lo demás fallará también y te ahorra el
-recorrido.
+### Antes de empezar — dos cosas que ya han costado tiempo
 
-### 11. ⬜ Prueba de función de alarma (201.12.3.105)
+**1. Flashea LAS DOS placas.** En esta tanda cambiaron el enum de alarmas
+(17 condiciones), `CTRL,STATE` (tres campos nuevos y uno con significado nuevo),
+`CTRL,ALM` (prioridad) y `CTRL,ALM_HISTORY` (campo `resolved`). Una placa vieja
+contra un display nuevo **descarta líneas enteras**, y los síntomas no se
+parecen en nada a la causa.
 
-Ajustes → **PROBAR ALARMAS**, con el equipo sin ninguna alarma activa.
+**2. Comprueba que el binario es el que crees.** Ajustes → Información: la
+versión del HMI lleva pegada la marca de compilación, del estilo
+`4.0.0 (Aug 17 2026 00:14:32)`. Si no coincide con la hora a la que compilaste,
+**para y flashea otra vez**. Dos rondas de depuración se fueron en una placa
+sin reflashear.
 
-- Suenan **tres ráfagas** seguidas, de menos a más urgente, separadas por medio
-  segundo: 1 pulso, luego 3, luego 10. Duración total ~6 s.
-- La de ALTA se oye como **cinco pulsos, pausa, cinco pulsos** — no como diez
-  seguidos. Esa agrupación es el patrón de la Tabla 3 y es lo que la hace
-  reconocible; si suena monótona, el hueco de grupo no está saliendo.
-- El banner aparece **en la propia pantalla de ajustes** (no solo en el
-  bloqueo) y cambia de color con cada tramo: cian fijo → ámbar parpadeando
-  lento → rojo parpadeando rápido.
-- Con una alarma real activa, el botón **no hace nada**: la placa lo rechaza.
-- Provoca una alarma real a mitad de la prueba (desconecta el ventilador): la
-  prueba se **corta en el acto** y suena la alarma de verdad.
+**Orden recomendado.** Haz el **11** primero: ejercita de una vez el zumbador,
+el banner, los tres patrones y los tres colores. Si falla, casi todo lo demás
+fallará y te ahorra el recorrido. Después el **17**, porque un enlace que no se
+recupera bien contamina todas las lecturas posteriores.
 
-### 12. ⬜ Registro de alarmas
+---
 
-- Provoca una alarma y ábrela: aparece a la vez en **Activas** y en
-  **Registro**, ahí como "sin resolver".
-- Resuélvela **con el centro de alarmas abierto**: baja sola de Activas a
-  Registro y la fila se pone **verde**, sin cerrar y reabrir.
-- Si la placa no tiene hora (sin WiFi), la fila resuelta dice "resuelta" en vez
-  de una fecha. Que salga verde igualmente es el punto: antes se quedaba en
-  "sin resolver" para siempre porque el centinela de hora chocaba con el de
-  resolución.
-- Pulsa una fila del registro: sale el pop-up con la descripción. Si dice
-  "descripción no disponible", la placa no está contestando `CTRL,ALM_DESC`.
-- Reinicia el equipo: el registro **sobrevive**. Ojo, el blob subió a versión 2
-  y los registros anteriores se descartan una sola vez — la primera vez tras
-  actualizar sale vacío, y es correcto.
+### 11. Prueba de función de alarma (201.12.3.105) — pendiente
 
-### 13. ⬜ Silencio por condición
+**Preparación.** Equipo encendido y **sin ninguna alarma activa**: si el icono
+de alarmas de la barra muestra un número, resuelve antes lo que haya.
 
-- Con dos alarmas activas, silencia **una**: la otra sigue sonando (6.8.1).
-- La fila silenciada muestra el icono de campana con X discontinua y el texto
-  AUDIO EN PAUSA; la otra no.
-- Aparece el icono permanente arriba a la derecha, **en todas las pantallas**.
-- El botón cambia a **REANUDAR**. Púlsalo: el audio vuelve de inmediato (6.8.4).
-- Deja pasar los **10 minutos** sin tocar nada: el audio vuelve solo y el botón
-  se ofrece otra vez. Esto es lo que estaba roto y lo que más conviene
-  confirmar; con cronómetro, porque el plazo hay que declararlo en las
-  instrucciones de uso.
-- Provoca el corte de red (desenchufa): su fila sale con **NO SILENCIABLE**
-  desactivado, y no se puede callar (201.12.3.103).
+**Pasos.**
+1. Abre el centro de alarmas — icono de la barra, o el check verde si no hay
+   alarmas.
+2. Pulsa **PROBAR**, arriba a la izquierda de la tarjeta.
 
-### 14. ⬜ Banner y navegación
+**Debe ocurrir.** Una secuencia de unos 6 s con tres ráfagas, de menos a más
+urgente, separadas por medio segundo:
 
-- El banner solo aparece en la **pantalla de bloqueo**. Sal del bloqueo con una
-  alarma sonando: desaparece **al instante**, sin esperar al siguiente cambio
-  de alarma. Ese era el fallo del cálculo perezoso.
-- Pulsar el banner abre el centro de alarmas sin desbloquear.
-- **Sin ninguna alarma**, pulsar el check verde de la pantalla principal abre
-  el centro de alarmas. En el bloqueo el check **no** es pulsable, a propósito:
-  ahí el toque desbloquea.
+| Tramo | Pulsos | Banner |
+|---|---|---|
+| BAJA | 1 | cian, **fijo** |
+| MEDIA | 3 | ámbar, parpadeo **lento** (~0,75 s) |
+| ALTA | 10 | rojo, parpadeo **rápido** (~0,25 s) |
 
-### 15. ⬜ Chasquido de confirmación
+Y tres detalles que son el objeto de la prueba:
 
-- Suena al tocar botones, interruptores y tarjetas.
-- **No** suena al tocar el fondo ni un panel decorativo.
-- **No** suena al escribir en el teclado del asistente de bebé (ni una tecla).
-- **Sí** suena al cambiar de pestaña en las gráficas.
-- Juicio a oído: ¿el clic se oye **más** que la alarma? Si es que sí —y hoy lo
-  es— apúntalo: es el hallazgo de nivel sonoro que va con la medida acústica.
+- La de ALTA se oye como **cinco pulsos, pausa, cinco pulsos**. No como diez
+  seguidos. Esa agrupación (el hueco de `2x + y` de la Tabla 3) es lo que hace
+  reconocible la máxima prioridad frente a otro equipo de la sala.
+- El banner se pinta **encima de la propia tarjeta** del centro de alarmas.
+  Antes se suprimía ahí y la prueba salía muda de vista.
+- Cada pulso tiene **rampa de subida y bajada**; no arranca de golpe.
 
-### 16. ⬜ Averías por cable
+**Si falla.**
+- *No pasa nada y sale el aviso «Hay una alarma activa»*: hay una condición
+  señalizando que la pantalla puede no estar mostrando. Mira el log de la
+  placa (`[ALARM] prueba rechazada: bitmask=0x…`) y decodifica el bitmask.
+- *Suena pero no hay banner*: el campo `almTest` de `CTRL,STATE` no llega.
+- *Banner pero no suena*: comprueba si el zumbador de la placa suena con
+  alarmas reales; si tampoco, el problema no es la prueba.
+- *Los diez pulsos suenan uniformes*: no se aplica el hueco de grupo —
+  `gapAfterPulse()` en `Buzzer.cpp`.
 
-Las tres se provocan desconectando algo, sin calentar nada.
+**Comprobación adicional.** Con una alarma real activa el botón debe negarse y
+decirlo. Y provocando una alarma a mitad de la prueba (desconecta el tacómetro
+del ventilador), la secuencia debe **cortarse en el acto** y sonar la alarma de
+verdad: una prueba nunca puede pisar una alarma real.
 
-- **Sonda de piel en corto**: puentea los dos pines del conector. El log dice
-  `CORTOCIRCUITO` con su resistencia, no `CIRCUITO ABIERTO`. En modo piel salta
-  la alarma ALTA y corta calefactor; en modo aire, la BAJA.
-- **Sonda desconectada**: el log dice `CIRCUITO ABIERTO`. Distinguirlas es todo
-  el objetivo del cambio.
-- **Ventilador**: desconecta el tacómetro (sin parar el aire) para probar el
-  detector, o el ventilador entero para probar el corte.
-- **Calefactor desconectado antes de arrancar**: sale `FALLO CALENTADOR` —el de
-  cableado—, **no** `FALLO SENSOR CALENTADOR`. Que salga el segundo significaría
-  que la separación quedó al revés.
+---
 
-### 17. ⬜ Enlace con el display
+### 12. Registro de alarmas (6.12.2) — pendiente
 
-- Desconecta el cable serie con el equipo en marcha: a los **5 s** la placa
-  declara `SIN ENLACE PANTALLA` (se ve en el log de la placa; el display, obvio,
-  ya no lo pinta).
-- Reconéctalo: la condición se retira sola.
-- **Enciende solo la placa, sin display**: no debe declararla nunca. Un enlace
-  que jamás existió no es un enlace caído, y si esto falla tendrás la alarma en
-  cada arranque.
+**Preparación.** Ten a mano una alarma fácil de provocar y de quitar. La de
+sonda de piel desconectada en modo aire es la más cómoda.
 
-### 18. ⬜ Que nada de lo anterior rompió lo de antes
+**Pasos.**
+1. Provoca la alarma y abre el centro de alarmas.
+2. Con el centro **abierto**, resuelve la alarma (reconecta la sonda).
+3. Pulsa la fila del registro.
+4. Reinicia el equipo y vuelve a abrir el registro.
 
-Rápido, pero conviene: control de temperatura en aire y en piel, humedad,
-fototerapia con temporizador, asistente de bebé y su teclado, historial de
-bebés. Se han tocado `Switch_cb`, los envíos de estado y el arranque de la UI.
+**Debe ocurrir.**
+- Paso 1: la alarma aparece **a la vez** en *Activas* y en *Registro*, ahí como
+  «sin resolver».
+- Paso 2: baja sola de *Activas* a *Registro* y la fila se pone **verde**, sin
+  cerrar y reabrir el centro.
+- Paso 3: sale un pop-up con la descripción de la alarma.
+- Paso 4: el registro **sobrevive** al reinicio.
+
+**Si falla.**
+- *La fila no baja sola*: el display no vuelve a pedir el registro al cambiar
+  el conjunto de alarmas activas (`activeIdSignature()`).
+- *Dice «descripción no disponible»*: la placa no contesta `CTRL,ALM_DESC`.
+- *El registro sale vacío tras actualizar*: **es correcto la primera vez**. El
+  blob de NVS subió a versión 2 y lo anterior se descarta una sola vez. Si sale
+  vacío la segunda vez, entonces sí es un fallo.
+
+**Sobre la hora.** Sin WiFi la placa no tiene reloj, así que la fila resuelta
+dirá «resuelta» en lugar de una fecha. **Que salga verde igualmente es el
+punto**: antes se quedaba en «sin resolver» para siempre, porque el centinela
+de hora chocaba con el de resolución.
+
+---
+
+### 13. Silencio por condición (6.8.1, 6.8.4, 6.8.5, 201.12.3.104) — pendiente
+
+> **Este punto tiene un fallo abierto**: `known_issues.md` #6 — el indicador no
+> se dibuja al silenciar. Ejecútalo igual, sirve para acotar el fix, pero
+> **empieza por la cuenta atrás**: es la sonda más barata. Si no baja,
+> `CTRL,STATE` no está llegando y el problema es de transporte, no de interfaz.
+
+**Preparación.** Dos alarmas activas a la vez, de condiciones distintas.
+
+**Pasos.**
+1. Silencia **una** de las dos.
+2. Observa la cuenta atrás de la esquina inferior derecha unos 10 s.
+3. Pulsa **REANUDAR** en esa misma fila.
+4. Vuelve a silenciarla y deja pasar los **10 minutos** completos, con
+   cronómetro.
+5. Desenchufa la alimentación de red para provocar esa alarma.
+
+**Debe ocurrir.**
+- La otra alarma **sigue sonando**: silenciar una no afecta a las demás (6.8.1).
+- La fila silenciada muestra la campana con X **discontinua** y «AUDIO EN
+  PAUSA»; la otra no.
+- Abajo a la derecha aparece la misma campana con la cuenta atrás, **en todas
+  las pantallas**, y el número **baja segundo a segundo**.
+- El botón dice **REANUDAR** en verde; al pulsarlo el audio vuelve de inmediato.
+- A los 10 minutos el audio vuelve solo y el botón se ofrece otra vez.
+- La fila del corte de red sale con **NO SILENCIABLE** desactivado y no se
+  puede callar: 201.12.3.103 exige 10 min de aviso y la pausa dura justo eso.
+
+**Si falla.** Consulta la tabla de descartes de `known_issues.md` #6 antes de
+investigar nada. El silencio en la placa, el formato, el `sscanf`, la longitud
+de línea, el índice de bit y el recorte del icono **ya están descartados con
+evidencia**.
+
+**Anota el plazo medido.** 6.8.5 obliga a declarar la duración del AUDIO PAUSED
+en las instrucciones de uso, así que el número del cronómetro es dato de
+expediente, no una curiosidad.
+
+---
+
+### 14. Banner y navegación — pendiente
+
+**Pasos.**
+1. Con una alarma sonando y la pantalla bloqueada, observa el banner.
+2. Púlsalo.
+3. Desbloquea y ve a la pantalla principal, con la alarma aún activa.
+4. Resuelve todas las alarmas y pulsa el **check verde** de la principal.
+5. Repite el paso 4 en la pantalla de bloqueo.
+
+**Debe ocurrir.**
+- El banner solo se ve **en el bloqueo**, arriba, con el color y el parpadeo de
+  la prioridad más alta.
+- Pulsarlo abre el centro de alarmas **sin desbloquear**.
+- Al salir del bloqueo **desaparece al instante**, no al siguiente cambio de
+  alarma. Ese era el fallo del cálculo perezoso.
+- El check verde de la principal **abre el centro de alarmas**.
+- En el bloqueo el check **no** es pulsable: ahí el toque desbloquea, y hacerlo
+  pulsable crearía una zona muerta permanente.
+
+**Si falla.** Que el banner tarde en desaparecer significa que
+`alarm_banner_update()` ha dejado de llamarse en cada pasada del bucle de UI.
+
+---
+
+### 15. Chasquido de confirmación — pendiente
+
+**Pasos.** Toca, por este orden: un botón, un interruptor, una tarjeta del
+centro de alarmas, el **fondo** de una pantalla, un panel decorativo, las
+**teclas** del asistente de bebé y una **pestaña** de las gráficas.
+
+**Debe ocurrir.**
+
+| Toque | ¿Suena? |
+|---|---|
+| Botón, interruptor, tarjeta | **Sí** |
+| Fondo o panel decorativo | **No** |
+| Teclas del asistente | **No**, ni una |
+| Pestaña de gráficas | **Sí** |
+
+**Si falla.** Que suene en el fondo significa que el filtro volvió a mirar
+`LV_OBJ_FLAG_CLICKABLE`, que LVGL pone en **todos** los objetos. Que suene en
+el teclado significa que se filtró solo por `lv_keyboard_class`, y el teclado
+del asistente es un `lv_btnmatrix` a propósito.
+
+**Juicio a oído, y es importante.** ¿El clic se oye **más** que la alarma? Hoy
+sí, y está al revés: el transductor de las alarmas debe ser lo más audible del
+equipo. Anótalo, porque es entrada de la medida acústica pendiente y puede
+acabar siendo un cambio de hardware.
+
+---
+
+### 16. Averías por cable — pendiente
+
+Las cuatro se provocan desconectando algo, sin calentar nada. Necesitas el log
+de la placa a la vista.
+
+| Avería | Cómo | Debe salir |
+|---|---|---|
+| Sonda de piel **en corto** | puentea los dos pines del conector | log `CORTOCIRCUITO` con su resistencia |
+| Sonda **desconectada** | quítala | log `CIRCUITO ABIERTO` |
+| **Ventilador** | desconecta el tacómetro (prueba el detector) o el ventilador entero (prueba el corte) | `FALLO VENTILADOR`, ALTA, corta calefactor |
+| **Calefactor** desconectado antes de arrancar | quítalo y enciende | `FALLO CALENTADOR` |
+
+**Qué se comprueba en cada una.**
+- Corto y circuito abierto **tienen que distinguirse**: es todo el objetivo de
+  la clasificación por resistencia. Si los dos dicen lo mismo, no sirvió.
+- La sonda en corto **en modo piel** es ALTA y corta calefactor; **en modo aire**
+  es BAJA. La urgencia depende del modo, no de la avería.
+- El calefactor desconectado debe dar `FALLO CALENTADOR` —el de cableado—, **no
+  `FALLO SENSOR CALENTADOR`**. Que salga el segundo significaría que la
+  separación de las dos averías quedó al revés.
+
+---
+
+### 17. Enlace entre placas, en los dos sentidos — pendiente
+
+**Pasos.**
+1. Con el equipo en marcha, **desconecta el cable serie** y cronometra.
+2. Observa la pantalla del display.
+3. Reconecta.
+4. Aparte: enciende **solo la placa**, sin display, y espera un minuto.
+
+**Debe ocurrir.**
+- A los **5 s** la placa declara `SIN ENLACE PANTALLA`, prioridad MEDIA: 3
+  pulsos cada ~25 s. Se ve en el log de la placa; el display, obviamente, ya no
+  lo pinta.
+- El display, por su lado, muestra el banner **SIN ENLACE CON LA PLACA** en
+  cualquier pantalla, y **las medidas pasan a `--`** con las barras a cero.
+  Esta es la parte de seguridad: una cifra congelada no se ve congelada.
+- Las **consignas se quedan**: son lo que pediste, no una medida.
+- Al reconectar, todo vuelve solo, sin reiniciar.
+- Arrancando sin display, la placa **no debe declarar la alarma nunca**. Un
+  enlace que jamás existió no es un enlace caído; si esto falla, tendrás la
+  alarma en cada encendido.
+
+**Si falla.** Que las cifras vuelvan a su valor viejo un segundo después de
+borrarse significa que alguno de los ocho llamantes de `update_labels()` está
+repintando sin respetar la guarda.
+
+---
+
+### 18. No-regresión de lo que ya funcionaba — pendiente
+
+Rápido, pero no lo saltes: esta tanda tocó `Switch_cb`, los envíos de estado,
+el arranque de la UI y el motor del zumbador.
+
+- Control de temperatura en **modo aire** y en **modo piel**, con sus flechas de
+  consigna.
+- **Humedad**: activar, ajustar, desactivar.
+- **Fototerapia** con temporizador: `+`/`−`, iniciar, cancelar y dejar que
+  expire sola.
+- **Asistente de bebé** completo, incluido escribir el nombre con el teclado.
+- **Historial de bebés**: lista, alta y gráfica de peso.
+- **Idiomas**: cambia a inglés y a francés y vuelve. Los textos nuevos —banner,
+  centro de alarmas, botón PROBAR— deben traducirse con el resto.
+
+**Presta atención a la fluidez.** Si la interfaz va lenta, sospecha de algo que
+se repinta en cada pasada del bucle de UI: ya pasó una vez con el banner, por
+llamar a `lv_label_set_text()` y `lv_obj_move_foreground()` incondicionalmente.
 
 ---
 

--- a/Firmware/motherBoard/include/tasks/DriveUpload.h
+++ b/Firmware/motherBoard/include/tasks/DriveUpload.h
@@ -33,11 +33,13 @@
 // the AFE4490 library's own probe-attached/raw-signal-valid flags, not a
 // derived HR quality metric. Filename gets a "DH_" prefix (driveWriteTask)
 // when any sample in the window sets this.
+// ppg_disp is float since library v0.69 (OT domain, A/A, ~1e-5..1e-6): as an
+// int32_t it truncated to 0 for every sample.
 struct DrivePpgSample {
   uint32_t t_ms;
   int32_t  led1_sub;
   int32_t  led2_sub;
-  int32_t  ppg_disp;
+  float    ppg_disp;
   bool     valid_signal;
 };
 

--- a/Firmware/motherBoard/include/tasks/PpgSnapshot.h
+++ b/Firmware/motherBoard/include/tasks/PpgSnapshot.h
@@ -63,8 +63,10 @@ void ppgSnapshotRelease();
 // sea true; el módulo no sabe nada de ThingsBoard/JSON — el llamador decide
 // cómo serializarlo (Wifi_OTA.cpp lo manda como serie temporal real, un
 // punto por muestra, para poder usar un chart estándar en el dashboard).
+// Las muestras son ppg_disp tal cual lo entrega la libreria: float en dominio
+// OT (A/A, ~1e-5..1e-6) desde la v0.69. Sin escalar ni normalizar aqui.
 uint16_t ppgSnapshotSampleCount();
-const int32_t *ppgSnapshotSamples();
+const float *ppgSnapshotSamples();
 
 // Libera el slot para la siguiente captura (llamar tras leer el buffer).
 void ppgSnapshotClear();

--- a/Firmware/motherBoard/src/drivers/SPO2.cpp
+++ b/Firmware/motherBoard/src/drivers/SPO2.cpp
@@ -23,7 +23,9 @@ void SPO2_Task(void *pvParameters) {
 
       if (++sample_count % SPO2_LOG_INTERVAL_SAMPLES == 0) {
         logSPO2("[SPO2] n=" + String(sample_count) +
-                " PPG=" + String(data.ppg_disp) + " RED=" + String(data.led2) +
+                // ppg_disp is a float (A/A) since library v0.69; String(float)'s
+                // default 2 decimals would print 0.00 for every sample.
+                " PPG=" + String(data.ppg_disp, 8) + " RED=" + String(data.led2) +
                 " IR=" + String(data.led1) + " RED_sub=" +
                 String(data.led2_sub) + " IR_sub=" + String(data.led1_sub) +
                 " SpO2=" + String(data.spo2_sqi > 0.0f ? data.spo2 : -1.0f, 1) +
@@ -52,9 +54,11 @@ void initSPO2() {
   // Initialize SPI bus for AFE4490 (CS=-1: managed per device via AFE44XX_CS)
   SPI.begin(AFE_SCK, AFE_MISO, AFE_MOSI, -1);
 
-  // HGAC (RF-only descent, lib v0.53): ships disabled. Enabled here because both
-  // LED channels sit at the ADC positive rail (~2^21) with no probe applied, and
-  // the resulting DC step on probe application swamps the SpO2 AC estimators.
+  // HGAC (RF-only; since lib v0.81 two EMAs per domain — a fast HIGH2 guard plus
+  // slow HIGH1/LOW1 levelling, so it now raises RF as well as lowering it): still
+  // ships disabled. Enabled here because both LED channels sit at the ADC positive
+  // rail (~2^21) with no probe applied, and the resulting DC step on probe
+  // application swamps the SpO2 AC estimators.
   afe.setHgacEnable(true);
 
   // Configure chip registers, attach DRDY ISR, launch internal processing task

--- a/Firmware/motherBoard/src/tasks/CommTask.cpp
+++ b/Firmware/motherBoard/src/tasks/CommTask.cpp
@@ -44,12 +44,21 @@ static SemaphoreHandle_t hmi_state_req_sem;
 
 static HardwareSerial &hmiSerial = Serial1;
 
-// PPG transport scale: ADC counts of ppg_disp per LSB of the 0-255 display range.
-// ppg_disp is zero-mean (library BPF output), so 128 is the baseline and this divisor
-// sets the half-range to 127 x 16 = ~2030 counts. Measured on the bench 2026-08-13
-// with HGAC active: peaks up to ~1350 counts at PI ~10%, so ~50% headroom.
+// PPG transport scale: ppg_disp units (A/A, OT domain) per LSB of the 0-255 display
+// range. ppg_disp is zero-mean (library BPF output), so 128 is the baseline and this
+// divisor sets the half-range to 127 x 1.6e-8 = ~2.0e-6 A/A.
+//
+// Library v0.69 moved ppg_disp to the OT domain: int32_t (ADC counts) -> float (A/A,
+// magnitude ~1e-5..1e-6), so it is gain-invariant and no longer jumps when HGAC
+// changes RF. The previous scale (16 ADC counts/LSB, measured on the bench
+// 2026-08-13) no longer applies to these units.
+//
+// This value is DERIVED from the library spec, not measured: typical OT DC is
+// ~1.4e-5 A/A and AC/DC = PI/100, so at PI ~10% (the operating point of the original
+// bench measurement) ppg_disp peaks at ~1.4e-6 — same ~50% headroom the old counts
+// scale had. TODO: re-validate on the bench with a real probe.
 // Fixed on purpose — no adaptive scaling outside the library.
-static constexpr int32_t PPG_DISP_COUNTS_PER_LSB = 16;
+static constexpr float PPG_DISP_UNITS_PER_LSB = 1.6e-8f;
 
 // ---- Phototherapy Timer (Motherboard is source of truth) ----
 static bool photoTimerActive = false;
@@ -993,7 +1002,14 @@ void Communication_Task(void *pvParameters) {
       // application (_spo2_update: EMAs reset while not APPLIED), while ppg_disp is
       // valid within ~1 s. Gating the trace on SpO2 validity flat-lined it for 19 s.
       if (g_spo2_data.probe_state == ProbeState::PROBE_APPLIED) {
-        long ppg_scaled = 128L + (long)(g_spo2_data.ppg_disp / PPG_DISP_COUNTS_PER_LSB);
+        // ppg_disp is a float since library v0.69: a non-finite value would make
+        // lroundf() undefined, so it collapses to the baseline instead of emitting
+        // a garbage byte. Keeping the line flowing (rather than skipping the send)
+        // preserves the 25 Hz cadence the HMI trace expects.
+        float ppg = g_spo2_data.ppg_disp;
+        long ppg_scaled = isfinite(ppg)
+                              ? 128L + lroundf(ppg / PPG_DISP_UNITS_PER_LSB)
+                              : 128L;
         uint8_t ppg_byte = (uint8_t)constrain(ppg_scaled, 0L, 255L);
         char ppg_msg[16];
         snprintf(ppg_msg, sizeof(ppg_msg), "CTRL,PPG,%u\n", ppg_byte);

--- a/Firmware/motherBoard/src/tasks/DriveUpload.cpp
+++ b/Firmware/motherBoard/src/tasks/DriveUpload.cpp
@@ -363,9 +363,12 @@ static void driveWriteTask(void *pv) {
       }
 
       uint32_t rel_ms = s.t_ms - window_start_ms;
-      char line[48];
-      int  n = snprintf(line, sizeof(line), "%u,%d,%d,%d\n", (unsigned)rel_ms,
-                        (int)s.led1_sub, (int)s.led2_sub, (int)s.ppg_disp);
+      // ppg_disp goes out as %.4e (A/A, OT domain) — the same wire format the
+      // library's own PulseNest frames adopted in v0.69. "%d" truncated every
+      // sample to 0. The buffer grew from 48 to 64: "-1.2345e-06" is 11 chars.
+      char line[64];
+      int  n = snprintf(line, sizeof(line), "%u,%d,%d,%.4e\n", (unsigned)rel_ms,
+                        (int)s.led1_sub, (int)s.led2_sub, s.ppg_disp);
       if (n > 0)
         ::write(csv_fd, line, n);
 

--- a/Firmware/motherBoard/src/tasks/PpgSnapshot.cpp
+++ b/Firmware/motherBoard/src/tasks/PpgSnapshot.cpp
@@ -2,7 +2,9 @@
 
 namespace {
 
-int32_t  s_buf[PPG_SNAPSHOT_SAMPLES];
+// float desde la v0.69 de la libreria: ppg_disp paso al dominio OT (A/A,
+// ~1e-5..1e-6) y como int32_t se truncaba a 0 en todas las muestras.
+float    s_buf[PPG_SNAPSHOT_SAMPLES];
 uint16_t s_count      = 0;     // muestras (ya diezmadas) recogidas
 uint16_t s_decimCount = 0;     // muestras crudas a 500 Hz desde la última guardada
 bool     s_capturing  = false;
@@ -70,7 +72,7 @@ bool ppgSnapshotIsReady() { return s_ready; }
 
 uint16_t ppgSnapshotSampleCount() { return s_count; }
 
-const int32_t *ppgSnapshotSamples() { return s_buf; }
+const float *ppgSnapshotSamples() { return s_buf; }
 
 void ppgSnapshotClear() {
   s_ready = false;

--- a/Firmware/motherBoard/src/tasks/PpgSnapshotPublish.cpp
+++ b/Firmware/motherBoard/src/tasks/PpgSnapshotPublish.cpp
@@ -22,7 +22,7 @@ bool ppgSnapshotPublish(ThingsBoard &client, const char *tag) {
   }
 
   uint16_t const n = ppgSnapshotSampleCount();
-  int32_t const *samples = ppgSnapshotSamples();
+  float const *samples = ppgSnapshotSamples();
   if (!n || samples == nullptr) {
     ppgSnapshotRelease();
     return false;


### PR DESCRIPTION
Convierte los puntos 11-18 del bloque B en procedimientos ejecutables: **Preparacion / Pasos / Debe ocurrir / Si falla**, con tablas de resultado esperado.

- El apartado *Si falla* apunta al modulo concreto (`Buzzer.cpp`, `update_labels()`, `activeIdSignature()`...) para no repetir depuraciones a ciegas.
- Nueva seccion previa: flashear **las dos** placas y comprobar la marca de compilacion en Ajustes -> Informacion. Las dos causas que mas tiempo costaron en la tanda anterior.
- Orden recomendado: 11 primero (ejercita zumbador, banner y las tres prioridades de una vez), luego 17 (enlace).
- El punto 13 avisa del fallo abierto `known_issues.md` #6 y remite a su tabla de descartes.

Corrige detalles que la lista daba por buenos y ya no lo son: el boton PROBAR esta en la cabecera del centro de alarmas (no en ajustes), el indicador de AUDIO PAUSED esta abajo a la derecha y lleva cuenta atras, `CTRL,STATE` es periodico a 1 Hz y la version del HMI incluye marca de compilacion.

Solo documentacion, sin cambios de codigo.