### PR TITLE
fix(hmi): crear el panel RGB antes de arrancar el WiFi para evitar bucle de arranque

### DIFF
--- a/Firmware/Display_HMI/include/main.h
+++ b/Firmware/Display_HMI/include/main.h
@@ -274,6 +274,10 @@ constexpr int MS_PER_SECOND = 1000;
 // Startup
 // -----------------------------
 constexpr int STARTUP_DELAY_MS = 0;
+// Tope de espera en setup() a que UI_Task haya creado el panel RGB antes de
+// arrancar la tarea OTA/WiFi (ver comentario en main.cpp). En condiciones
+// normales el panel esta listo en ~400 ms; 5 s solo se agotan si el LCD falla.
+constexpr uint32_t LCD_READY_TIMEOUT_MS = 5000;
 
 // -----------------------------
 // Misc sizes / lengths

--- a/Firmware/Display_HMI/include/tasks/UITask.h
+++ b/Firmware/Display_HMI/include/tasks/UITask.h
@@ -54,6 +54,11 @@ bool UI_AnyControlActive(void);
 // que pueden NACKear una escritura vacia con hardware sano.
 bool UI_TouchInitOk(void);
 bool UI_BacklightInitOk(void);
+// True una vez esp_lcd_new_rgb_panel() ha reservado los bounce buffers (RAM
+// interna DMA). setup() espera a esto antes de crear la tarea OTA/WiFi: si el
+// WiFi conecta antes (SSID en NVS), fragmenta la RAM interna y el panel falla
+// con ESP_ERR_NO_MEM en bucle de arranque.
+bool UI_LcdPanelReady(void);
 void UI_UpdatePowerBars(int tempPwm, int humPwm);
 void UI_ApplyLanguage(ui_lang_t lang);
 void UI_SyncAll();

--- a/Firmware/Display_HMI/src/main.cpp
+++ b/Firmware/Display_HMI/src/main.cpp
@@ -129,14 +129,6 @@ void setup() {
 
   LVGL_Mutex_Init();
 
-#ifndef DISABLE_WIFI_TEST
-  ESP_LOGI(TAG, "Creating OTA task ...");
-  CreateOTATask();
-  ESP_LOGI(TAG, "OTA task successfully created!");
-#else
-  ESP_LOGW(TAG, "[DISABLE_WIFI_TEST] WiFi/OTA task NOT created — bench test build");
-#endif
-
   ESP_LOGI(TAG, "Creating Communication task ...");
   CreateCommTask();
   ESP_LOGI(TAG, "Communication task successfully created!");
@@ -144,6 +136,37 @@ void setup() {
   ESP_LOGI(TAG, "Creating UI task ...");
   CreateUITask();
   ESP_LOGI(TAG, "UI task successfully created!");
+
+  // La tarea OTA/WiFi se crea la ULTIMA y solo cuando el panel RGB ya tiene
+  // sus bounce buffers (RAM interna DMA, dos bloques contiguos de ~38 KB).
+  // Con SSID guardado en NVS el WiFi conectaba a los ~300 ms y la pila
+  // WiFi/lwIP fragmentaba la RAM interna antes de que UI_Task creara el
+  // panel: esp_lcd_new_rgb_panel() fallaba con ESP_ERR_NO_MEM y el Display
+  // entraba en bucle de arranque (~1,2 s por vuelta, pantalla en blanco).
+  // El timeout es una red de seguridad: si el LCD no llega a inicializarse,
+  // el WiFi/OTA arranca igual para no perder la via de recuperacion remota.
+  {
+    uint32_t waited_ms = 0;
+    while (!UI_LcdPanelReady() && waited_ms < LCD_READY_TIMEOUT_MS) {
+      vTaskDelay(pdMS_TO_TICKS(10));
+      waited_ms += 10;
+    }
+    if (UI_LcdPanelReady()) {
+      ESP_LOGI(TAG, "LCD panel ready after %lu ms — starting WiFi/OTA",
+               (unsigned long)waited_ms);
+    } else {
+      ESP_LOGE(TAG, "LCD panel NOT ready after %lu ms — starting WiFi/OTA anyway",
+               (unsigned long)waited_ms);
+    }
+  }
+
+#ifndef DISABLE_WIFI_TEST
+  ESP_LOGI(TAG, "Creating OTA task ...");
+  CreateOTATask();
+  ESP_LOGI(TAG, "OTA task successfully created!");
+#else
+  ESP_LOGW(TAG, "[DISABLE_WIFI_TEST] WiFi/OTA task NOT created — bench test build");
+#endif
 
 #ifdef CRASH_TEST
   xTaskCreatePinnedToCore(CrashTestTask, "CRASH_TEST", 2048, NULL, 1, NULL, 1);

--- a/Firmware/Display_HMI/src/tasks/UITask.cpp
+++ b/Firmware/Display_HMI/src/tasks/UITask.cpp
@@ -40,6 +40,15 @@ static const char *TAG = "UI";
 static bool s_touchInitOk = false;
 static bool s_backlightInitOk = false;
 
+// Se levanta en UI_Task() justo despues de esp_lcd_new_rgb_panel(): a partir
+// de ahi los bounce buffers (RAM interna con DMA, dos bloques contiguos) ya
+// estan reservados. setup() lo consulta para no arrancar el WiFi antes: la
+// pila WiFi/lwIP fragmenta la RAM interna y, en un Display con SSID guardado
+// en NVS, GOT_IP llegaba ~40 ms antes que la creacion del panel y este moria
+// con ESP_ERR_NO_MEM en bucle de arranque. Volatile: lo escribe UI_Task y lo
+// lee setup() desde la tarea principal.
+static volatile bool s_lcdPanelReady = false;
+
 SemaphoreHandle_t g_lvgl_mutex = NULL;
 
 void LVGL_Mutex_Init(void) {
@@ -1566,6 +1575,7 @@ bool UI_AnyControlActive() {
 
 bool UI_TouchInitOk(void) { return s_touchInitOk; }
 bool UI_BacklightInitOk(void) { return s_backlightInitOk; }
+bool UI_LcdPanelReady(void) { return s_lcdPanelReady; }
 
 // Runs everything the temperature switch's ON branch used to do inline,
 // now invoked from BabyWizard's "Apply" step once the mandatory baby-data
@@ -3942,6 +3952,7 @@ void UI_Task(void *pvParameters) {
     ESP_LOGW("LCD", "RGB panel initialized OK  [HEAP] internal=%u PSRAM=%u",
              (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL),
              (unsigned)heap_caps_get_free_size(MALLOC_CAP_SPIRAM));
+    s_lcdPanelReady = true;  // setup() puede arrancar ya la tarea OTA/WiFi
   }
 
   lv_init();


### PR DESCRIPTION
**Síntoma.** Display en blanco reiniciando cada ~1,2 s (49 reinicios/min medidos por serie). WiFi intermitente y servidor OTA inalcanzable.

**Causa.** `setup()` crea la tarea OTA/WiFi antes que la UI. Con SSID en NVS, el WiFi conecta a los ~300 ms y la pila WiFi/lwIP fragmenta la RAM interna. Cuando `UI_Task` llama a `esp_lcd_new_rgb_panel()` (~340 ms) no encuentra dos bloques contiguos de ~38 KB en RAM interna DMA para los bounce buffers (24 líneas desde `f4115c33`) → `ESP_ERR_NO_MEM` → `abort()`.
Log: `lcd_rgb_panel_alloc_frame_buffers(185): no mem for bounce buffer`.

**Por qué no se ve en banco.** Sin WiFi configurado no hay `GOT_IP` antes del panel y arranca bien. Se dispara solo en Displays con credenciales guardadas, es decir, en unidades desplegadas.

**Solución.** `UI_Task` levanta `UI_LcdPanelReady()` justo tras crear el panel; `setup()` la espera (tope `LCD_READY_TIMEOUT_MS` = 5 s) antes de crear la tarea OTA/WiFi. Si el LCD fallara, el WiFi arranca igual para no perder el OTA. Comm y UI conservan su orden relativo.

**Verificación.** CrowPanel 7.0 (sn 317), log serie: panel listo a 240 ms, WiFi después, 0 reinicios en 40 s. Compila solo sobre `dev` (`main`: RAM 43,2 %, Flash 83,7 %).

**Nota.** Explica los "fallos de OTA" del Display desde junio: no era el servidor, era que moría antes de atender.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
