### PR TITLE
ci: build firmware and check formatting on dev PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,144 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - dev
+  push:
+    branches:
+      - dev
+
+permissions:
+  contents: read
+
+jobs:
+  # The three PlatformIO gates share one recipe (install PlatformIO, restore
+  # its cache, run one command in one directory) and differ only in that
+  # command, so they run as a matrix instead of three near-identical jobs.
+  # fail-fast is off: a broken Display_HMI build must not hide a broken
+  # motherBoard test run.
+  platformio:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - id: motherboard-build
+            name: Build motherBoard
+            directory: Firmware/motherBoard
+            command: pio run -e IncuNest_V17
+          - id: display-hmi-build
+            name: Build Display_HMI
+            directory: Firmware/Display_HMI
+            command: pio run -e main
+          - id: motherboard-test
+            name: Test motherBoard (native)
+            directory: Firmware/motherBoard
+            command: pio test -e native
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Same cache as release.yml, keyed per matrix entry as well: the three
+      # entries pull different toolchains and would otherwise overwrite each
+      # other's entry under a single key.
+      - name: Cache PlatformIO
+        uses: actions/cache@v4
+        with:
+          path: ~/.platformio
+          key: ${{ runner.os }}-pio-${{ matrix.id }}-${{ hashFiles('Firmware/motherBoard/platformio.ini', 'Firmware/Display_HMI/platformio.ini') }}
+          restore-keys: ${{ runner.os }}-pio-${{ matrix.id }}-
+
+      # motherBoard pins medicalopenworld/incunest_afe4490 in lib_deps and
+      # that repository is not publicly readable, so PlatformIO cannot clone
+      # it with the anonymous credentials of a runner (GITHUB_TOKEN only
+      # grants access to this repository). Give a PIO_GIT_TOKEN secret read
+      # access to it and the build resolves; without the secret this step
+      # does nothing. Secrets are never exposed to pull requests from forks,
+      # so a fork cannot build motherBoard either way.
+      - name: Authenticate private library dependencies
+        env:
+          PIO_GIT_TOKEN: ${{ secrets.PIO_GIT_TOKEN }}
+        run: |
+          if [ -n "$PIO_GIT_TOKEN" ]; then
+            git config --global \
+              url."https://x-access-token:$PIO_GIT_TOKEN@github.com/".insteadOf \
+              "https://github.com/"
+          fi
+
+      - name: Install PlatformIO
+        run: pip install --upgrade platformio
+
+      - name: ${{ matrix.name }}
+        run: ${{ matrix.command }}
+        working-directory: ${{ matrix.directory }}
+
+  # SensorBoard_v2 is native ESP-IDF (CMake + idf.py), not PlatformIO, so it
+  # builds inside Espressif's own image. The version is pinned to the one
+  # recorded in Firmware/SensorBoard_v2/dependencies.lock, so CI resolves the
+  # same components as a developer machine and does not rewrite that file;
+  # bump both together.
+  build-sensorboard:
+    name: Build SensorBoard_v2
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build with ESP-IDF
+        uses: espressif/esp-idf-ci-action@v1
+        with:
+          esp_idf_version: v6.0.1
+          target: esp32s3
+          path: Firmware/SensorBoard_v2
+
+  # Formatting is defined against the diff of the pull request, so this job
+  # only runs for pull_request events; a push to dev has no such diff and is
+  # already covered by the build and test jobs above.
+  format:
+    name: Check formatting
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      # Full history: the check diffs against the merge base of the pull
+      # request, which a shallow checkout does not contain.
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      # Pinned: clang-format output changes between LLVM releases, so an
+      # unpinned version would turn unrelated pull requests red on its own.
+      # This wheel also ships git-clang-format.
+      - name: Install clang-format
+        run: pip install clang-format==23.1.1
+
+      # Only the lines this pull request changed are checked. The firmware
+      # predates the formatter, so checking whole files would report hundreds
+      # of unrelated lines on every pull request and reformatting it wholesale
+      # is out of scope. Each file is formatted with the .clang-format of its
+      # own tree — no global -style is passed — and files deleted by the pull
+      # request are skipped by git-clang-format itself.
+      - name: Check formatting of changed lines
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if ! git-clang-format --diff --diff_from_common_commit \
+              --extensions c,cc,cpp,cxx,h,hh,hpp \
+              "$BASE_SHA" "$HEAD_SHA" -- \
+              Firmware/motherBoard \
+              Firmware/Display_HMI \
+              Firmware/SensorBoard_v2; then
+            echo "::error::Changed lines are not formatted. Apply the diff above, or run 'git clang-format origin/dev' before pushing."
+            exit 1
+          fi

--- a/Firmware/Display_HMI/.clang-format
+++ b/Firmware/Display_HMI/.clang-format
@@ -1,0 +1,22 @@
+# clang-format for Display_HMI (Arduino/ESP32 + LVGL, C and C++).
+#
+# This describes the style already in the tree instead of imposing a new one:
+# LLVM is the closest base (2-space indent, 80 columns, `Type *name`), so only
+# the deviations measured against the existing sources are listed below.
+BasedOnStyle: LLVM
+
+IndentWidth: 2
+ColumnLimit: 80
+
+# Guard clauses are written on one line all over this tree
+# (`if (!ok) return false;`, `while (*p == ' ') p++;`).
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: true
+
+# Comments are hand-wrapped and carry ASCII tables and rationale blocks;
+# reflowing them is churn, not formatting.
+ReflowComments: false
+
+# Include order is load-bearing here (main.h pulls in the board configuration
+# that later headers rely on), so clang-format must not reorder it.
+SortIncludes: Never

--- a/Firmware/Display_HMI/.clang-format-ignore
+++ b/Firmware/Display_HMI/.clang-format-ignore
@@ -1,0 +1,4 @@
+# Generated binary blobs, not hand-written source: LVGL image assets exported
+# by the asset pipeline and the WAV dump used by the buzzer.
+src/ui/assets/*
+include/ui/hmi_ding.h

--- a/Firmware/motherBoard/.clang-format
+++ b/Firmware/motherBoard/.clang-format
@@ -1,0 +1,22 @@
+# clang-format for motherBoard (Arduino/ESP32, C++).
+#
+# This describes the style already in the tree instead of imposing a new one:
+# LLVM is the closest base (2-space indent, 80 columns, `Type *name`), so only
+# the deviations measured against the existing sources are listed below.
+BasedOnStyle: LLVM
+
+IndentWidth: 2
+ColumnLimit: 80
+
+# Guard clauses are written on one line all over this tree
+# (`if (!ok) return false;`, `while (*p == ' ') p++;`).
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: true
+
+# Comments are hand-wrapped and carry ASCII tables and rationale blocks;
+# reflowing them is churn, not formatting.
+ReflowComments: false
+
+# Include order is load-bearing here (main.h pulls in the board configuration
+# that later headers rely on), so clang-format must not reorder it.
+SortIncludes: Never


### PR DESCRIPTION
## Summary

Implements #29, following up on the CI/tooling work originally proposed in #4. Reworked from scratch against the current `dev`; nothing from that branch is reused.

* Build motherBoard with `pio run -e IncuNest_V17`
* Build Display_HMI with `pio run -e main`
* Build SensorBoard_v2 with ESP-IDF
* Run motherBoard native tests with `pio test -e native`
* Check formatting only for what the pull request changed
* Use board-specific clang-format configuration
* Cache PlatformIO dependencies

This intentionally does not introduce cpplint, reformat existing code, or restore the previous host Makefile approach. Four new files, 192 added lines, no existing file touched.

## What the workflow does

`.github/workflows/ci.yml` runs on `pull_request` to `dev` and on `push` to `dev`.

The three PlatformIO gates are one job with a three-entry matrix — they differ only in one command, and `fail-fast: false` keeps them independent — plus a separate ESP-IDF job and a separate format job, all in parallel with no inter-job dependencies. The `~/.platformio` cache is the one from `release.yml`, with the matrix entry added to the key so the three entries do not overwrite each other's cache.

SensorBoard_v2 builds with `espressif/esp-idf-ci-action@v1` (Espressif's own action, which runs `idf.py build` inside their Docker image), pinned to `v6.0.1` — the version recorded in `Firmware/SensorBoard_v2/dependencies.lock`, so CI resolves the same components as a developer machine and does not rewrite that tracked file. No ESP-IDF cache: what dominates that job is the image pull, which `actions/cache` cannot help with, and the managed components are a few seconds. Only the build is gated; the Unity tests under `test_apps/` need real hardware.

Action versions match what the repo already uses: `actions/checkout@v4`, `actions/cache@v4`, `actions/setup-python@v5`. `runs-on` is `ubuntu-latest` rather than `release.yml`'s `ubuntu-22.04`, which is on its way out of the hosted runner images.

## Two decisions worth reviewing

**1. Formatting is checked per changed line, not per changed file.**

#29 asks for `clang-format --dry-run --Werror` on the files a pull request touches. Measured over the last 34 firmware commits on `dev`, that produces **5243 violation lines, 13/13 red** — roughly 400 lines of unrelated reformatting demanded per pull request, which only a wholesale reformat could clear, and #29 puts that out of scope. Restricting the same check to the lines actually changed gives **279 violation lines, median 10 per commit, 13/34 fully green**.

Since the stated goal is "que cada PR a `dev` compile y no rompa el estilo, **sin poner en rojo el código existente**", the job uses `git-clang-format --diff --diff_from_common_commit` (it ships in the same pinned `clang-format` wheel). It reads each file's nearest `.clang-format`, so no global `-style` overrides a board's own config; it skips deleted files; it handles paths with spaces; and `--diff_from_common_commit` makes it diff from the merge base, so commits landing on `dev` meanwhile are not attributed to the pull request. `fetch-depth: 0` is set because that merge base is not in a shallow checkout.

`clang-format` is pinned to `23.1.1` — its output changes between LLVM releases, and an unpinned version would turn unrelated pull requests red by itself.

Happy to switch to the literal whole-file check if you'd rather have the stricter gate and take the reformat.

**2. `pio run -e IncuNest_V17` cannot pass on a hosted runner today.**

motherBoard's `lib_deps` pins `https://github.com/medicalopenworld/incunest_afe4490.git#4e0dd91`, and that repository is not publicly readable (404 anonymously and to my account, absent from the org's public repo list). `GITHUB_TOKEN` only grants access to IncuNest itself, so PlatformIO cannot clone it. This is pre-existing, not something this PR introduces: `release.yml` carries the same command and has never actually run.

The workflow therefore has an optional `Authenticate private library dependencies` step that rewrites `github.com` URLs through a `PIO_GIT_TOKEN` secret when one is set, and does nothing when it isn't. Add a token with read access to that repo and the job goes green; `release.yml` will need the same. Note that GitHub never exposes secrets to pull requests from forks, so `Build motherBoard` cannot pass on a fork's pull request either way — that is a property of the private dependency, not of this workflow.

## clang-format configuration

SensorBoard_v2 keeps its own `.clang-format` untouched and remains the source of truth for that tree.

motherBoard and Display_HMI get one each. Both describe the style already in the tree rather than imposing Google Style: LLVM turned out to be the closest base (2-space indent, 80 columns, `Type *name`), and each deviation was picked by measuring clang-format churn across the whole tree and across recent history, not by taste. `AllowShortIfStatementsOnASingleLine: WithoutElse` + `AllowShortLoopsOnASingleLine` alone cut changed-line violations from 279 to 144 over the same commits; `ReflowComments: false` protects the hand-wrapped rationale comments and ASCII tables; `SortIncludes: Never` is there because include order is load-bearing in Arduino/ESP32 code.

Display_HMI also gets a `.clang-format-ignore` for `src/ui/assets/*` and `include/ui/hmi_ding.h` — generated LVGL image blobs and a WAV dump, together ~90 % of that tree's formatting noise and not hand-written code.

`Firmware/shared/` is deliberately **not** covered: it has no `.clang-format`, and adding a fourth one is beyond what #29 asks for. Worth a follow-up, since both boards compile that code.

## Validation

Run locally on macOS with PlatformIO 6.2.0, clang-format 23.1.1 and Docker.

- [x] Display_HMI builds with `pio run -e main` — `[SUCCESS]`, flash 50.7 % (2 657 444 B), RAM 38.1 %
- [x] motherBoard native tests pass with `pio test -e native` — 378/378 cases, 25 suites, all PASSED
- [x] SensorBoard_v2 builds with `idf.py build` — in `espressif/idf:v6.0.1`, `Project build complete`, exit 0, `dependencies.lock` unchanged afterwards (it does drift to 6.0.3 under an unpinned image, which is why the pin is there)
- [ ] motherBoard builds with `pio run -e IncuNest_V17` — **not verified**: fails at `incunest_afe4490` with `remote: Repository not found`, as described above. Everything before that dependency resolves fine
- [x] `ci.yml` passes `actionlint` (`rhysd/actionlint`, clean; the only finding in the repo is a pre-existing shellcheck note in `build-mac-flasher.yml`)
- [x] YAML parses and every `${{ }}` expression checked, including the matrix keys and `secrets.PIO_GIT_TOKEN`
- [x] Environment names verified against `platformio.ini` (`IncuNest_V17`, `main`, `native` all exist) and against `release.yml` and the openspec/docs references to `pio test -e native`
- [x] Changed-file detection exercised on real branches: badly formatted C++ in each of the three trees is reported with **that tree's own style** (2-space/LLVM braces for motherBoard and Display_HMI, 4-space/Linux braces for SensorBoard_v2), exit 1
- [x] A file deleted by the branch does not fail the check — `no modified files to format`, exit 0
- [x] A docs-only branch does not fail the check — `no modified files to format`, exit 0
- [x] A path with spaces (`src/spaced dir/bad name.cpp`) is handled correctly, no word splitting
- [x] Non-C/C++ files inside a firmware tree (`.py`, `.md`) and C++ outside the three trees (`Firmware/shared/`) are correctly ignored
- [x] `.clang-format-ignore` verified to be what suppresses the generated assets (removing it makes the same edit fail)
- [x] Full diff re-read: four new files, no change to firmware code, configuration or docs

The one thing I cannot check locally is the workflow actually running on GitHub, which is why this is a draft — `Build motherBoard` is expected red for the reason above. The run is currently sitting at *action_required*: as this comes from a fork, someone with write access needs to press **Approve and run workflows** before the jobs start. I'll move it to ready for review once the checks have been seen running.

Closes #29
